### PR TITLE
Fix main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hue-sdk",
   "version": "0.0.1",
   "description": "Phillips Hue API library",
-  "main": "hue-sdk.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Previously it said `hue-sdk.js` was the main file, so I had trouble importing the module
